### PR TITLE
refactor: transform load_configuration into a template function

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -9,17 +9,15 @@ target_link_libraries(nephtys_client_shared_deps INTERFACE
         CONAN_PKG::doom_strong_types
         nephtys::loguru
         nephtys::default_settings
-        $<$<CXX_COMPILER_ID:GNU>:-static-libstdc++>
-        $<$<PLATFORM_ID:Linux>:stdc++fs>
-        $<$<PLATFORM_ID:Darwin>:c++fs>)
+        nephtys::common
+        $<$<CXX_COMPILER_ID:GNU>:-static-libstdc++>)
 
 target_sources(nephtys_client_shared_deps INTERFACE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/config/config.cpp
         $<$<PLATFORM_ID:Linux>:${CMAKE_CURRENT_SOURCE_DIR}/src/resources/details/linux/app_image_real_path.cpp>)
 
 target_include_directories(nephtys_client_shared_deps INTERFACE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/common/include)
+        ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 
 target_enable_asan(nephtys_client_shared_deps)

--- a/client/include/nephtys/client/config/config.hpp
+++ b/client/include/nephtys/client/config/config.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <filesystem>
 #include <string>
 #include <nlohmann/json.hpp>
 #include <nephtys/strong_types/size.hpp>
@@ -60,8 +59,6 @@ namespace nephtys::client
 
         win_cfg window; //!< window data information
     };
-
-    config load_configuration(std::filesystem::path &&config_path) noexcept;
 
     void from_json(const nlohmann::json &json_data, config &game_cfg);
 

--- a/client/src/config/config.cpp
+++ b/client/src/config/config.cpp
@@ -2,9 +2,7 @@
 // Created by milerius on 05/04/19.
 //
 
-#include <loguru.hpp>
 #include <nephtys/client/config/config.hpp>
-#include <fstream>
 
 inline constexpr const char window_json_field[] = "window";
 inline constexpr const char window_size_json_field[] = "size";
@@ -58,39 +56,5 @@ namespace nephtys::client
     bool win_cfg::operator!=(const win_cfg &rhs_win) const noexcept
     {
         return !(rhs_win == *this);
-    }
-}
-
-namespace nephtys::client
-{
-    config load_configuration(std::filesystem::path &&config_path) noexcept
-    {
-        VLOG_SCOPE_F(loguru::Verbosity_INFO, __FUNCTION__);
-        nlohmann::json config_json_data;
-        config loaded_config{};
-        const auto &fullpath = config_path / "nephtys_client.config.json";
-        DVLOG_F(loguru::Verbosity_INFO, "path to nephtys configuration -> %s", fullpath.string().c_str());
-        if (!std::filesystem::exists(config_path)) {
-            DVLOG_F(loguru::Verbosity_WARNING,
-                    "path to nephtys configuration doesn't exist, creating directories + configuration for you");
-            std::error_code ec;
-            std::filesystem::create_directories(config_path, ec);
-            if (ec) {
-                VLOG_F(loguru::Verbosity_WARNING, "creating directories failed: %s, returning default configuration",
-                       ec.message().c_str());
-                return loaded_config;
-            }
-            std::ofstream ofs(fullpath);
-            DCHECK_F(ofs.is_open(), "Failed to open: [%s]", fullpath.string().c_str());
-            config_json_data = loaded_config;
-            DVLOG_F(loguru::Verbosity_INFO, "default game config: [%s]", config_json_data.dump().c_str());
-            ofs << config_json_data;
-        } else {
-            std::ifstream ifs(fullpath);
-            DCHECK_F(ifs.is_open(), "Failed to open: [%s]", fullpath.string().c_str());
-            ifs >> config_json_data;
-            loaded_config = config_json_data;
-        }
-        return loaded_config;
     }
 }

--- a/client/src/config/config.test.cpp
+++ b/client/src/config/config.test.cpp
@@ -3,8 +3,8 @@
 //
 
 #include <doctest.h>
+#include <nephtys/utils/config.hpp>
 #include <nephtys/client/config/config.hpp>
-#include <fstream>
 
 namespace nephtys::client
 {
@@ -33,11 +33,12 @@ namespace nephtys::client
                     AND_WHEN("we load the configuration from a root directory") {
                         THEN("we got a default configuration") {
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
-                            REQUIRE_EQ(load_configuration("/toto"), config{});
+                            REQUIRE_EQ(utils::load_configuration<client::config>("/toto", "nephtys_client.config.json"),
+                                       config{});
                             REQUIRE_FALSE(std::filesystem::exists("/toto"));
 
 #else
-                    auto res = load_configuration(std::filesystem::path("G:\\toto"));
+                    auto res = utils::load_configuration<client::config>(std::filesystem::path("G:\\toto"), "nephtys_client.config.json");
                     REQUIRE_EQ(res, config{});
                     auto path_exist = std::filesystem::exists("G:\\toto");
                     REQUIRE_FALSE(path_exist);
@@ -46,7 +47,9 @@ namespace nephtys::client
             }
                     AND_WHEN ("we load the configuration from a non root directory") {
                         THEN("we create a default configuration in the given path and we got a default configuration") {
-                            REQUIRE_EQ(load_configuration(std::filesystem::current_path() / "assets/config"), config{});
+                            REQUIRE_EQ(
+                            utils::load_configuration<client::config>(std::filesystem::current_path() / "assets/config",
+                                                                      "nephtys_client.config.json"), config{});
                             REQUIRE(std::filesystem::exists(
                             std::filesystem::current_path() / "assets/config/nephtys_client.config.json"));
                 }
@@ -71,7 +74,9 @@ namespace nephtys::client
                     AND_WHEN("We load the configuration from this fresh directories") {
                         THEN("We got this config") {
                     config game_cfg{{st::height{1200u}, st::width{800u}, "nephtys", false}};
-                            REQUIRE_EQ(load_configuration(std::move(path)), game_cfg);
+                            REQUIRE_EQ(
+                            utils::load_configuration<client::config>(std::move(path), "nephtys_client.config.json"),
+                            game_cfg);
                 }
                         AND_THEN("We clear the directory that we create for this test") {
                     std::filesystem::remove_all(std::filesystem::current_path() / "assets");

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,3 +1,11 @@
+add_library(nephtys-common INTERFACE)
+target_include_directories(nephtys-common INTERFACE include)
+target_link_libraries(nephtys-common INTERFACE
+        $<$<PLATFORM_ID:Linux>:stdc++fs>
+        $<$<PLATFORM_ID:Darwin>:c++fs>)
+add_library(nephtys::common ALIAS nephtys-common)
+
+
 add_executable(nephtys-common-test)
 target_sources(nephtys-common-test PRIVATE src/version.test.cpp test/test.common.cpp)
 target_link_libraries(nephtys-common-test PRIVATE CONAN_PKG::doctest nephtys::default_settings)

--- a/common/include/nephtys/utils/config.hpp
+++ b/common/include/nephtys/utils/config.hpp
@@ -1,0 +1,45 @@
+//
+// Created by sztergbaum roman on 2019-04-19.
+//
+
+#pragma once
+
+#include <filesystem>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <loguru.hpp>
+
+namespace nephtys::utils
+{
+    template<typename TConfig>
+    TConfig load_configuration(std::filesystem::path &&config_path, std::string filename) noexcept
+    {
+        VLOG_SCOPE_F(loguru::Verbosity_INFO, __FUNCTION__);
+        nlohmann::json config_json_data;
+        TConfig loaded_config{};
+        const auto &fullpath = config_path / std::move(filename);
+        DVLOG_F(loguru::Verbosity_INFO, "path to nephtys configuration -> %s", fullpath.string().c_str());
+        if (!std::filesystem::exists(config_path)) {
+            DVLOG_F(loguru::Verbosity_WARNING,
+                    "path to nephtys configuration doesn't exist, creating directories + configuration for you");
+            std::error_code ec;
+            std::filesystem::create_directories(config_path, ec);
+            if (ec) {
+                VLOG_F(loguru::Verbosity_WARNING, "creating directories failed: %s, returning default configuration",
+                       ec.message().c_str());
+                return loaded_config;
+            }
+            std::ofstream ofs(fullpath);
+            DCHECK_F(ofs.is_open(), "Failed to open: [%s]", fullpath.string().c_str());
+            config_json_data = loaded_config;
+            DVLOG_F(loguru::Verbosity_INFO, "default game config: [%s]", config_json_data.dump().c_str());
+            ofs << config_json_data;
+        } else {
+            std::ifstream ifs(fullpath);
+            DCHECK_F(ifs.is_open(), "Failed to open: [%s]", fullpath.string().c_str());
+            ifs >> config_json_data;
+            loaded_config = config_json_data;
+        }
+        return loaded_config;
+    }
+}

--- a/common/include/nephtys/utils/config.hpp
+++ b/common/include/nephtys/utils/config.hpp
@@ -11,15 +11,14 @@
 
 namespace nephtys::utils
 {
-    template<typename TConfig>
-    TConfig load_configuration(std::filesystem::path &&config_path, std::string filename) noexcept
+    namespace details
     {
-        VLOG_SCOPE_F(loguru::Verbosity_INFO, __FUNCTION__);
-        nlohmann::json config_json_data;
-        TConfig loaded_config{};
-        const auto &fullpath = config_path / std::move(filename);
-        DVLOG_F(loguru::Verbosity_INFO, "path to nephtys configuration -> %s", fullpath.string().c_str());
-        if (!std::filesystem::exists(config_path)) {
+        template<typename TConfig>
+        TConfig create_configuration(std::filesystem::path &&config_path,
+                                     const std::filesystem::path &full_path) noexcept
+        {
+            TConfig config_to_export{};
+            VLOG_SCOPE_F(loguru::Verbosity_INFO, __FUNCTION__);
             DVLOG_F(loguru::Verbosity_WARNING,
                     "path to nephtys configuration doesn't exist, creating directories + configuration for you");
             std::error_code ec;
@@ -27,19 +26,41 @@ namespace nephtys::utils
             if (ec) {
                 VLOG_F(loguru::Verbosity_WARNING, "creating directories failed: %s, returning default configuration",
                        ec.message().c_str());
-                return loaded_config;
+                return config_to_export;
             }
-            std::ofstream ofs(fullpath);
-            DCHECK_F(ofs.is_open(), "Failed to open: [%s]", fullpath.string().c_str());
-            config_json_data = loaded_config;
+            std::ofstream ofs(full_path);
+            DCHECK_F(ofs.is_open(), "Failed to open: [%s]", full_path.string().c_str());
+            nlohmann::json config_json_data;
+            config_json_data = config_to_export;
             DVLOG_F(loguru::Verbosity_INFO, "default game config: [%s]", config_json_data.dump().c_str());
             ofs << config_json_data;
-        } else {
-            std::ifstream ifs(fullpath);
-            DCHECK_F(ifs.is_open(), "Failed to open: [%s]", fullpath.string().c_str());
-            ifs >> config_json_data;
-            loaded_config = config_json_data;
+            return config_to_export;
         }
-        return loaded_config;
+
+        template<typename TConfig>
+        TConfig load_configuration(const std::filesystem::path &full_path) noexcept
+        {
+            TConfig config_to_fill{};
+            VLOG_SCOPE_F(loguru::Verbosity_INFO, __FUNCTION__);
+            std::ifstream ifs(full_path);
+            DCHECK_F(ifs.is_open(), "Failed to open: [%s]", full_path.string().c_str());
+            nlohmann::json config_json_data;
+            ifs >> config_json_data;
+            config_to_fill = config_json_data;
+            return config_to_fill;
+        }
+    }
+
+    template<typename TConfig>
+    TConfig load_configuration(std::filesystem::path &&config_path, std::string filename) noexcept
+    {
+        VLOG_SCOPE_F(loguru::Verbosity_INFO, __FUNCTION__);
+        const auto &full_path = config_path / std::move(filename);
+        DVLOG_F(loguru::Verbosity_INFO, "path to nephtys configuration -> %s", full_path.string().c_str());
+        if (!std::filesystem::exists(config_path)) {
+            return details::create_configuration<TConfig>(std::forward<std::filesystem::path>(config_path),
+                                                          full_path);
+        }
+        return details::load_configuration<TConfig>(full_path);
     }
 }

--- a/common/include/nephtys/utils/config.hpp
+++ b/common/include/nephtys/utils/config.hpp
@@ -14,7 +14,7 @@ namespace nephtys::utils
     namespace details
     {
         template<typename TConfig>
-        TConfig create_configuration(std::filesystem::path &&config_path,
+        TConfig create_configuration(const std::filesystem::path &config_path,
                                      const std::filesystem::path &full_path) noexcept
         {
             TConfig config_to_export{};
@@ -58,8 +58,7 @@ namespace nephtys::utils
         const auto &full_path = config_path / std::move(filename);
         DVLOG_F(loguru::Verbosity_INFO, "path to nephtys configuration -> %s", full_path.string().c_str());
         if (!std::filesystem::exists(config_path)) {
-            return details::create_configuration<TConfig>(std::forward<std::filesystem::path>(config_path),
-                                                          full_path);
+            return details::create_configuration<TConfig>(config_path, full_path);
         }
         return details::load_configuration<TConfig>(full_path);
     }

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -9,14 +9,13 @@ target_link_libraries(nephtys_launcher
         PRIVATE CONAN_PKG::sfml
         PUBLIC
         nephtys::default_settings
+        nephtys::common
         $<$<CXX_COMPILER_ID:GNU>:-static-libstdc++>
-        $<$<PLATFORM_ID:Linux>:stdc++fs>
         PRIVATE
         nephtys::noesis)
 
 target_include_directories(nephtys_launcher PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/common/include
         ${PROJECT_SOURCE_DIR}/vendor/noesisgui/include)
 
 if (APPLE)

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -10,8 +10,8 @@ target_link_libraries(nephtys_server
         CONAN_PKG::jsonformoderncpp
         PUBLIC
         nephtys::default_settings
+        nephtys::common
         $<$<CXX_COMPILER_ID:GNU>:-static-libstdc++>
-        $<$<PLATFORM_ID:Linux>:stdc++fs>
         )
 
 if (LINUX)


### PR DESCRIPTION
Knowing that there will be three different executables, it's smarter to go through a template function for configuration loading.

- Signature take now an additional `string` filename and it is templated on the configuration you want to load.