### PR TITLE
lgtm.yml: remove GCC 8 requirement

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -14,7 +14,6 @@ extraction:
       - conan --version
       - cmake --version
       - conan profile new default --detect
-      - conan profile update settings.compiler.version=8 default
       - conan profile update settings.compiler.libcxx=libstdc++11 default
       - conan remote update conan-center https://conan.bintray.com False
       - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan False


### PR DESCRIPTION
This will let the project continue to work when the lgtm.com build environment is upgraded to Ubuntu 19.10, where the default compiler is  GCC 9.

I've tested that the build still works at https://lgtm.com/logs/e97dfa6a986ef20b7469fc3eec022e60919a10cd/lang:cpp.